### PR TITLE
fixed: inputs getting lost while logging a new vehicle

### DIFF
--- a/main.c
+++ b/main.c
@@ -65,7 +65,7 @@ typedef struct {
 typedef struct {
     char vehicleMake[50];
     char vehicleModel[50];
-    char vehicleYear[5];
+    char vehicleYear[20];
     char licensePlate[20];
     char vehicleColor[30];
     char mileage[15];


### PR DESCRIPTION
In the VehicleRecord struct, I changed the array size of VehicleColor[] from 5 to 20.
calling fgets when the array size of VehicleColor is 5 causes an overflow when you type 4 characters
because of the extra '\n' and '\0' padded at the end of the VehicleColor[] string. This overflow
causes some unpredictable behavior